### PR TITLE
.github: Set dynamic run-name to distinguish package name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,8 @@ on:
         - autoconf
         - devcontainer
 
+run-name: "Release: ${{ inputs.package }}"
+
 jobs:
   release-to-ghcr:
     concurrency:


### PR DESCRIPTION
![Screenshot from 2024-10-08 09-18-23](https://github.com/user-attachments/assets/05969ce6-80cc-4570-b286-28d871fbc3b8)

Currently, no way to distinguish which packages were released. It will help to distinguish job lists.