### PR TITLE
Autoconf shell requirements fix

### DIFF
--- a/autoconf/Dockerfile
+++ b/autoconf/Dockerfile
@@ -5,7 +5,7 @@ ARG AUTOCONF_ARCHIVE_VERSION="2023.02.20"
 ARG AUTOMAKE_VERSION="1.16.5"
 
 LABEL org.opencontainers.image.source="https://github.com/python/cpython-devcontainers"
-LABEL org.opencontainers.image.base.name="docker.io/library/alpine:3.19"
+LABEL org.opencontainers.image.base.name="docker.io/library/ubuntu:22.04"
 LABEL org.opencontainers.image.authors="Donghee Na"
 LABEL org.opencontainers.image.title="GNU Autoconf ${AUTOCONF_VERSION} container for CPython"
 LABEL org.opencontainers.image.description="Container image with GNU Autoconf ${AUTOCONF_VERSION}, GNU Automake ${AUTOMAKE_VERSION}, and autoconf-archive ${AUTOCONF_ARCHIVE_VERSION} for generating CPython's configure script."

--- a/autoconf/entry.sh
+++ b/autoconf/entry.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+export CONFIG_SHELL="/usr/bin/bash"
+
 BIN=/usr/local/bin
 AUTOCONF=$BIN/autoconf
 AUTORECONF=$BIN/autoreconf


### PR DESCRIPTION
Problem with autoconf
```
Rebuilding configure script using /usr/local/bin/autoconf: This script requires a shell more modern than all
```
in some contexts is fixed with some 'standard' technique.

See https://stackoverflow.com/questions/161064/autoconf-using-sh-i-need-shell-bash-how-do-i-force-autoconf-to-use-bash/161128#161128.

Also LABEL org.opencontainers.image.base.name is changed.
It looks like it was a typo in Dockerfilse since ```FROM``` value differs from ```image.base.name```. 

Unfortunately, these changes are not tested by myself since there is no any build instructions.
Simple
```docker build .```
fails with an error
```
The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 871920D1991BC93C
```