### PR TITLE
Update patch for ax_c_float_words_bigendian.m4

### DIFF
--- a/autoconf/ax_c_float_words_bigendian.diff
+++ b/autoconf/ax_c_float_words_bigendian.diff
@@ -58,7 +58,7 @@ index 216b90d8..52036844 100644
  #   warranty.
  
 -#serial 11
-+#serial 12
++#serial 14
  
  AC_DEFUN([AX_C_FLOAT_WORDS_BIGENDIAN],
    [AC_CACHE_CHECK(whether float word ordering is bigendian,
@@ -82,11 +82,11 @@ index 216b90d8..52036844 100644
  ]])], [
  
 -if grep noonsees conftest.$ac_objext >/dev/null ; then
-+if grep noonsees conftest$EXEEXT >/dev/null ; then
++if grep noonsees conftest* > /dev/null ; then
    ax_cv_c_float_words_bigendian=yes
  fi
 -if grep seesnoon conftest.$ac_objext >/dev/null ; then
-+if grep seesnoon conftest$EXEEXT >/dev/null ; then
++if grep seesnoon conftest* >/dev/null ; then
    if test "$ax_cv_c_float_words_bigendian" = unknown; then
      ax_cv_c_float_words_bigendian=no
    else


### PR DESCRIPTION
The original patch:
https://github.com/autoconf-archive/autoconf-archive/pull/279 broke endianness detection on Emscripten. This was fixed in this followup: https://github.com/autoconf-archive/autoconf-archive/pull/316

We also have worked around the problem by adjusting `configure.ac` in the Python repo to handle this case:
https://github.com/python/cpython/pull/126387
But it's useful for us to use the upstream autoconf-archive detection so that we can be completely sure that the fix works in practice.

cc @erlend-aasland 