### PR TITLE
Support multi-arch builds in the devcontainer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build_devcontainer:
-    name: Build (Devcontainer)
+    name: Build and test (Devcontainer)
     runs-on: ubuntu-latest
     env:
       TAG: cpython-devcontainer:1.0.0-${{ github.run_id }}
@@ -24,6 +24,10 @@ jobs:
           context: ./devcontainer
           load: true
           tags: ${{ env.TAG }}
+      - name: Test WASI SDK
+        run: docker run --rm ${{ env.TAG }} /opt/wasi-sdk/bin/clang --version
+      - name: Test Wasmtime
+        run: docker run --rm ${{ env.TAG }} /usr/local/bin/wasmtime --version
 
   build_autoconf:
     name: Build and test (Autoconf)

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -1,13 +1,9 @@
 FROM docker.io/library/fedora:41
 
+ARG TARGETARCH
+
+
 ENV CC=clang
-
-ENV WASI_SDK_VERSION=24
-ENV WASI_SDK_PATH=/opt/wasi-sdk
-
-ENV WASMTIME_HOME=/opt/wasmtime
-ENV WASMTIME_VERSION=22.0.0
-ENV WASMTIME_CPU_ARCH=x86_64
 
 RUN dnf -y --nodocs --setopt=install_weak_deps=False --disablerepo=fedora-cisco-openh264 install \
         /usr/bin/{blurb,clang,curl,git,ln,tar,xz} \
@@ -19,12 +15,30 @@ RUN dnf -y --nodocs --setopt=install_weak_deps=False --disablerepo=fedora-cisco-
         builddep python3 && \
     dnf -y clean all
 
+
+ENV WASI_SDK_VERSION=24
+ENV WASI_SDK_PATH=/opt/wasi-sdk
+
 RUN mkdir ${WASI_SDK_PATH} && \
-    curl --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-x86_64-linux.tar.gz | \
+    case "${TARGETARCH}" in \
+        amd64) WASI_ARCH="x86_64" ;; \
+        arm64) WASI_ARCH="arm64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-${WASI_ARCH}-linux.tar.gz | \
     tar --strip-components 1 --directory ${WASI_SDK_PATH} --extract --gunzip
 
+
+ENV WASMTIME_HOME=/opt/wasmtime
+ENV WASMTIME_VERSION=33.0.0
+
 RUN mkdir --parents ${WASMTIME_HOME} && \
-    curl --location "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-${WASMTIME_CPU_ARCH}-linux.tar.xz" | \
+    case "${TARGETARCH}" in \
+        amd64) WASMTIME_ARCH="x86_64" ;; \
+        arm64) WASMTIME_ARCH="aarch64" ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl --location "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz" | \
     xz --decompress | \
     tar --strip-components 1 --directory ${WASMTIME_HOME} -x && \
     ln -s ${WASMTIME_HOME}/wasmtime /usr/local/bin


### PR DESCRIPTION
Make WASI SDK and Wasmtime work under x86-64 and arm64.