### PR TITLE
Move devcontainer installation to shell scripts

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -2,47 +2,23 @@ FROM docker.io/library/fedora:41
 
 ARG TARGETARCH
 
-
 ENV CC=clang
 
-RUN dnf -y --nodocs --setopt=install_weak_deps=False --disablerepo=fedora-cisco-openh264 install \
-        /usr/bin/{blurb,clang,curl,git,ln,tar,xz} \
-        compiler-rt \
-        # TODO: remove when Fedora version includes Python 3.14+
-        libzstd-devel \
-        'dnf5-command(builddep)' && \
-    dnf -y --nodocs --setopt=install_weak_deps=False --disablerepo=fedora-cisco-openh264 \
-        builddep python3 && \
-    dnf -y clean all
-
+# Remove a video codec repository to speed up installs
+RUN dnf config-manager setopt fedora-cisco-openh264.enabled=False
 
 # Update only after consulting with WASI support maintainers (see PEP 11).
 ENV WASI_SDK_VERSION=24
 ENV WASI_SDK_PATH=/opt/wasi-sdk
 
-RUN mkdir ${WASI_SDK_PATH} && \
-    case "${TARGETARCH}" in \
-        amd64) WASI_ARCH="x86_64" ;; \
-        arm64) WASI_ARCH="arm64" ;; \
-        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
-    esac && \
-    curl --location https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-${WASI_ARCH}-linux.tar.gz | \
-    tar --strip-components 1 --directory ${WASI_SDK_PATH} --extract --gunzip
-
-
 # Update as desired.
 ENV WASMTIME_VERSION=33.0.0
 ENV WASMTIME_HOME=/opt/wasmtime
 
-RUN mkdir --parents ${WASMTIME_HOME} && \
-    case "${TARGETARCH}" in \
-        amd64) WASMTIME_ARCH="x86_64" ;; \
-        arm64) WASMTIME_ARCH="aarch64" ;; \
-        *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;; \
-    esac && \
-    curl --location "https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz" | \
-    xz --decompress | \
-    tar --strip-components 1 --directory ${WASMTIME_HOME} -x && \
-    ln -s ${WASMTIME_HOME}/wasmtime /usr/local/bin
 
+RUN mkdir -p /opt/cpython-devcontainer/bin
+COPY --chmod=755 install-builddeps.sh install-wasi.sh /opt/cpython-devcontainer/bin/
+RUN chmod +x /opt/cpython-devcontainer/bin/install-*.sh
 
+RUN /opt/cpython-devcontainer/bin/install-builddeps.sh
+RUN /opt/cpython-devcontainer/bin/install-wasi.sh

--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -18,7 +18,6 @@ ENV WASMTIME_HOME=/opt/wasmtime
 
 RUN mkdir -p /opt/cpython-devcontainer/bin
 COPY --chmod=755 install-builddeps.sh install-wasi.sh /opt/cpython-devcontainer/bin/
-RUN chmod +x /opt/cpython-devcontainer/bin/install-*.sh
 
 RUN /opt/cpython-devcontainer/bin/install-builddeps.sh
 RUN /opt/cpython-devcontainer/bin/install-wasi.sh

--- a/devcontainer/install-builddeps.sh
+++ b/devcontainer/install-builddeps.sh
@@ -1,0 +1,23 @@
+#! /bin/bash -ex
+
+# Install build tools and CPython dependencies on Fedora.
+
+
+# Define dependencies as an array, for easier formatting & comments.
+# see: https://www.gnu.org/software/bash/manual/html_node/Arrays.html
+DEPS=(
+    /usr/bin/{blurb,clang,curl,git,ln,tar,xz}
+    'dnf5-command(builddep)'
+
+    # LLVM sanitizer runtimes
+    compiler-rt
+
+    # TODO: remove when Fedora version includes Python 3.14
+    libzstd-devel
+)
+
+dnf -y --nodocs --setopt=install_weak_deps=False install ${DEPS[@]}
+dnf -y --nodocs --setopt=install_weak_deps=False builddep python3
+
+# Don't leave caches in the container
+dnf -y clean all

--- a/devcontainer/install-wasi.sh
+++ b/devcontainer/install-wasi.sh
@@ -1,0 +1,34 @@
+#! /bin/bash -ex
+
+# Install the WASI SDK.
+# This should be portable to any Linux, but is only tested in the devcontainer.
+
+
+mkdir ${WASI_SDK_PATH}
+
+case "${TARGETARCH}" in
+    amd64) WASI_ARCH="x86_64" ;;
+    arm64) WASI_ARCH="arm64" ;;
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;;
+esac && \
+
+URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-${WASI_ARCH}-linux.tar.gz
+
+curl --location $URL | tar --strip-components 1 --directory ${WASI_SDK_PATH} --extract --gunzip
+
+
+mkdir --parents ${WASMTIME_HOME}
+
+case "${TARGETARCH}" in
+    amd64) WASMTIME_ARCH="x86_64" ;;
+    arm64) WASMTIME_ARCH="aarch64" ;;
+    *) echo "Unsupported TARGETARCH: ${TARGETARCH}" && exit 1 ;;
+esac
+
+URL="https://github.com/bytecodealliance/wasmtime/releases/download/v${WASMTIME_VERSION}/wasmtime-v${WASMTIME_VERSION}-${WASMTIME_ARCH}-linux.tar.xz"
+
+curl --location $URL |
+    xz --decompress |
+    tar --strip-components 1 --directory ${WASMTIME_HOME} -x
+
+ln -s ${WASMTIME_HOME}/wasmtime /usr/local/bin


### PR DESCRIPTION
Would it make sense to use shell scripts to make the installation scripts more reusable, and avoid backslash line continuation?

I've separated like this:
- left in `Dockerfile`: removing the `openh264` repo, and the env variables
- `install-builddeps.sh`: Fedora (DNF)-specific installation of the needed tools
- `install-wasi.sh`: (theoretically portable) installation of the WASI SDK

I converted the list of dependencies to a Bash array, a somewhat obscure feature that has nicer syntax.

I put them in `/opt/cpython-devcontainer/bin/`, not `/usr/local/bin/`, so they're *not* on the default `$PATH` -- that would make them too discoverable.
