### PR TITLE
Symlink `/opt/wasi-sdk` instead of directly unpacking to it

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -10,15 +10,14 @@ ARG TARGETARCH
 
 ENV CC=clang
 
-# Remove a video codec repository to speed up installs
+# Remove a video codec repository to speed up installs.
 RUN dnf config-manager setopt fedora-cisco-openh264.enabled=False
 
 # Update only after consulting with WASI support maintainers (see PEP 11).
 ENV WASI_SDK_VERSION=24
-ENV WASI_SDK_PATH=/opt/wasi-sdk
 
 # Update as desired.
-ENV WASMTIME_VERSION=33.0.0
+ENV WASMTIME_VERSION=35.0.0
 ENV WASMTIME_HOME=/opt/wasmtime
 
 

--- a/devcontainer/install-wasi.sh
+++ b/devcontainer/install-wasi.sh
@@ -3,9 +3,6 @@
 # Install the WASI SDK.
 # This should be portable to any Linux, but is only tested in the devcontainer.
 
-
-mkdir ${WASI_SDK_PATH}
-
 case "${TARGETARCH}" in
     amd64) WASI_ARCH="x86_64" ;;
     arm64) WASI_ARCH="arm64" ;;
@@ -14,7 +11,10 @@ esac && \
 
 URL=https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_SDK_VERSION}/wasi-sdk-${WASI_SDK_VERSION}.0-${WASI_ARCH}-linux.tar.gz
 
-curl --location $URL | tar --strip-components 1 --directory ${WASI_SDK_PATH} --extract --gunzip
+curl --location $URL | tar --directory /opt --extract --gunzip
+
+# For Python 3.13 as Tools/wasm/wasi.py expects /opt/wasi-sdk.
+ln -s /opt/wasi-sdk-${WASI_SDK_VERSION}.0*/ /opt/wasi-sdk
 
 
 mkdir --parents ${WASMTIME_HOME}


### PR DESCRIPTION
This is to use the `latest` label in the CPython repo thanks to `Toosl/wasm/wasi` looking for unpacked WASI SDK installs in Python 3.15 and 3.14.

Also bump the version of wasmtime while we are here.