### PR TITLE
Bump to Fedora 42 for JIT

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/library/fedora:41
+FROM docker.io/library/fedora:42
 
-LABEL org.opencontainers.image.base.name="docker.io/library/fedora:41"
+LABEL org.opencontainers.image.base.name="docker.io/library/fedora:42"
 LABEL org.opencontainers.image.source="https://github.com/python/cpython-devcontainers"
 LABEL org.opencontainers.image.title="CPython development container"
 LABEL org.opencontainers.image.description="CPython development container with the tooling to work on Linux builds."


### PR DESCRIPTION
Once https://github.com/python/cpython/pull/140329 is merged, we'll need Fedora 42 to get LLVM 20.1.8 OOTB.