### PR TITLE
Bump to Fedora 43 for JIT builds with LLVM 21

### DIFF
--- a/devcontainer/Dockerfile
+++ b/devcontainer/Dockerfile
@@ -1,6 +1,6 @@
-FROM docker.io/library/fedora:42
+FROM docker.io/library/fedora:43
 
-LABEL org.opencontainers.image.base.name="docker.io/library/fedora:42"
+LABEL org.opencontainers.image.base.name="docker.io/library/fedora:43"
 LABEL org.opencontainers.image.source="https://github.com/python/cpython-devcontainers"
 LABEL org.opencontainers.image.title="CPython development container"
 LABEL org.opencontainers.image.description="CPython development container with the tooling to work on Linux builds."


### PR DESCRIPTION
Related to https://github.com/python/cpython/pull/140973, we'll need Fedora 43 to get LLVM 21 OOTB in the Devcontainer